### PR TITLE
[💄layout] 카카오, 네이버 로그인 버튼 UI 추가(Mobile ver) 

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,13 +4,13 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
     project: './tsconfig.json',
-    sourceType: 'module', 
-    ecmaVersion: 2020, 
+    sourceType: 'module',
+    ecmaVersion: 2020,
   },
   extends: [
     'airbnb',
-    "airbnb-typescript",
-    "airbnb/hooks",
+    'airbnb-typescript',
+    'airbnb/hooks',
     'prettier',
     'plugin:react/recommended',
     'plugin:prettier/recommended',
@@ -21,13 +21,19 @@ module.exports = {
   ],
   plugins: ['react', '@typescript-eslint', 'react-hooks', 'react-refresh'],
   rules: {
+    'react/function-component-definition': 'off',
+    'react/button-has-type': 'off',
+    'import/no-extraneous-dependencies': 'off',
     'react/jsx-filename-extension': [1, { extensions: ['.ts', '.tsx'] }],
     'react/react-in-jsx-scope': 'off',
     'prettier/prettier': ['error'],
     'import/prefer-default-export': 0,
     'import/extensions': 0,
     'import/no-unresolved': 0,
-    'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    'react-refresh/only-export-components': [
+      'warn',
+      { allowConstantExport: true },
+    ],
   },
   ignorePatterns: ['dist', '.eslintrc.cjs'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "fe-nextjs",
       "version": "0.1.0",
       "dependencies": {
+        "clsx": "^2.1.1",
         "next": "14.2.3",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "react-icons": "^5.2.1"
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "^14.2.3",
@@ -1456,6 +1458,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -4313,6 +4323,14 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.2.1.tgz",
+      "integrity": "sha512-zdbW5GstTzXaVKvGSyTaBalt7HSfuK5ovrzlpyiWHAFXndXTdd/1hdDHI4xBM1Mn7YriT6aqESucFl9kEXzrdw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "clsx": "^2.1.1",
     "next": "14.2.3",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "react-icons": "^5.2.1"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^14.2.3",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --kakao-bg: #fee500;
+  --naver-bg: #03c75a;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,8 +16,9 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className={NOTO_SANS_KR.className}>
-        <Header />
-        {children}
+        <div className="mobile:gap-mobile-gutter tablet:gap-tablet-gutter laptop:grid-cols-laptop-12 laptop:gap-laptop-gutter mx-4 grid mobile:grid-cols-mobile-4 tablet:grid-cols-tablet-8">
+          <main className="">{children}</main>
+        </div>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import './globals.css';
 import { Noto_Sans_KR } from 'next/font/google';
-import { Header } from '@/widgets';
 
 const NOTO_SANS_KR = Noto_Sans_KR({
   preload: true,
@@ -16,8 +15,8 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className={NOTO_SANS_KR.className}>
-        <div className="mobile:gap-mobile-gutter tablet:gap-tablet-gutter laptop:grid-cols-laptop-12 laptop:gap-laptop-gutter mx-4 grid mobile:grid-cols-mobile-4 tablet:grid-cols-tablet-8">
-          <main className="">{children}</main>
+        <div className="mx-4 grid mobile:grid-cols-mobile-4 mobile:gap-mobile tablet:grid-cols-tablet-8 tablet:gap-tablet desktop:grid-cols-desktop-12 desktop:gap-desktop">
+          <main className="col-span-full">{children}</main>
         </div>
       </body>
     </html>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,5 @@
+import { Login } from "@/widgets";
+
+export default function Page() {
+    return <Login />
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,0 +1,2 @@
+export { default as Logo } from './ui/Logo';
+export { default as Button } from './ui/Button';

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -16,9 +16,9 @@ const Button: React.FC<ButtonProps> = ({
   type = 'normal',
 }) => {
   const buttonClass = clsx(
-    'h-[54px] px-4 py-2 rounded-md flex items-center justify-center focus:outline-none focus:ring-2',
+    'h-[54px] w-full px-4 py-2 rounded-md flex items-center justify-center focus:outline-none focus:ring-2',
     {
-      'bg-[var(--kakao-bg)] hover:bg-[var(--kakao-bg)] text-black focus:ring-[var(--kakao-bg)]':
+      'bg-[var(--kakao-bg)] hover:bg-yellow-400 text-black focus:ring-[var(--kakao-bg)]':
         type === 'kakao',
       'bg-[var(--naver-bg)] hover:bg-green-600 text-white focus:ring-green-300':
         type === 'naver',
@@ -28,7 +28,7 @@ const Button: React.FC<ButtonProps> = ({
     className,
   );
   return (
-    <button onClick={onClick} className={`h-[54px] ${buttonClass}`}>
+    <button onClick={onClick} className={`${buttonClass}`}>
       {icon && <span className="mr-2 text-lg">{icon}</span>}
       {children}
     </button>

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -1,0 +1,38 @@
+import clsx from 'clsx';
+
+interface ButtonProps {
+  children: React.ReactNode;
+  onClick?: () => void;
+  className?: string;
+  icon?: React.ReactNode;
+  type?: 'kakao' | 'naver' | 'normal';
+}
+
+const Button: React.FC<ButtonProps> = ({
+  children,
+  onClick,
+  className,
+  icon,
+  type = 'normal',
+}) => {
+  const buttonClass = clsx(
+    'h-[54px] px-4 py-2 rounded-md flex items-center justify-center focus:outline-none focus:ring-2',
+    {
+      'bg-[var(--kakao-bg)] hover:bg-[var(--kakao-bg)] text-black focus:ring-[var(--kakao-bg)]':
+        type === 'kakao',
+      'bg-[var(--naver-bg)] hover:bg-green-600 text-white focus:ring-green-300':
+        type === 'naver',
+      'bg-blue-500 hover:bg-blue-700 text-white focus:ring-blue-300':
+        type === 'normal',
+    },
+    className,
+  );
+  return (
+    <button onClick={onClick} className={`h-[54px] ${buttonClass}`}>
+      {icon && <span className="mr-2 text-lg">{icon}</span>}
+      {children}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/shared/ui/Logo.tsx
+++ b/src/shared/ui/Logo.tsx
@@ -1,0 +1,3 @@
+export default function Logo() {
+    return <div>Logo</div>
+}

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -1,1 +1,2 @@
 export { default as Header } from './header/ui/Header';
+export {default as Login} from './login/ui/Login';

--- a/src/widgets/login/ui/KakaoLoginButton.tsx
+++ b/src/widgets/login/ui/KakaoLoginButton.tsx
@@ -1,0 +1,10 @@
+import { Button } from '@/shared';
+import { RiKakaoTalkFill } from 'react-icons/ri';
+
+export default function KakaoLoginButton() {
+  return (
+    <Button type="kakao" icon={<RiKakaoTalkFill />}>
+      카카오 로그인
+    </Button>
+  );
+}

--- a/src/widgets/login/ui/Login.tsx
+++ b/src/widgets/login/ui/Login.tsx
@@ -4,11 +4,11 @@ import NaverLoginButton from './NaverLoginButton';
 
 export default function Login() {
   return (
-    <div>
-      <div>
+    <div className="h-dvh">
+      <div className="flex h-[75%] items-center justify-center">
         <Logo />
       </div>
-      <div className="flex flex-col space-y-2">
+      <div className="h-[25%] space-y-4">
         <KakaoLoginButton />
         <NaverLoginButton />
       </div>

--- a/src/widgets/login/ui/Login.tsx
+++ b/src/widgets/login/ui/Login.tsx
@@ -1,0 +1,17 @@
+import { Logo } from '@/shared';
+import KakaoLoginButton from './KakaoLoginButton';
+import NaverLoginButton from './NaverLoginButton';
+
+export default function Login() {
+  return (
+    <div>
+      <div>
+        <Logo />
+      </div>
+      <div className="flex flex-col space-y-2">
+        <KakaoLoginButton />
+        <NaverLoginButton />
+      </div>
+    </div>
+  );
+}

--- a/src/widgets/login/ui/NaverLoginButton.tsx
+++ b/src/widgets/login/ui/NaverLoginButton.tsx
@@ -1,0 +1,10 @@
+import { Button } from '@/shared';
+import { SiNaver } from 'react-icons/si';
+
+export default function NaverLoginButton() {
+  return (
+    <Button type="naver" icon={<SiNaver />}>
+      네이버 로그인
+    </Button>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,13 +1,37 @@
-import type { Config } from "tailwindcss";
+import type { Config } from 'tailwindcss';
 
 const config: Config = {
   content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
     extend: {
+      colors: {
+        kakao: 'var(--kakao-bg)',
+        naver: 'var(--naver-bg)',
+      },
+      screens: {
+        mobile: { max: '374px' },
+        tablet: { min: '375px', max: '1024px' },
+        desktop: { min: '1025px' },
+      },
+      gridTemplateColumns: {
+        // Mobile
+        'mobile-4': 'repeat(4, minmax(0, 1fr))',
+
+        // Tablet
+        'tablet-8': 'repeat(8, minmax(0, 1fr))',
+
+        // Desktop
+        'desktop-12': 'repeat(12, minmax(0, 1fr))',
+      },
+      gap: {
+        mobile: '8px', // 8pt
+        tablet: '16px', // 16pt
+        desktop: '24px', // 24pt
+      },
       backgroundImage: {
-        "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
-        "gradient-conic":
-          "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
+        'gradient-conic':
+          'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
     },
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -28,11 +28,6 @@ const config: Config = {
         tablet: '16px', // 16pt
         desktop: '24px', // 24pt
       },
-      backgroundImage: {
-        'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
-        'gradient-conic':
-          'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
-      },
     },
   },
   plugins: [],


### PR DESCRIPTION
### 스크린샷
![image](https://github.com/CocoTrip/FE-next/assets/58039782/79b6eb09-699e-4086-970a-29ce73fe11f8)

### 작업 내용
- Button 공통 컴포넌트 개발
- clsx를 사용한 조건부 스타일 적용 
- Button 공통 컴포넌트를 이용한 네이버, 카카오 로그인 버튼 UI 개발 
- Logo 공통 컴포넌트 개발

### 노트
- Logo 공통 컴포넌트는 추후 로고 이미지 받은 후 수정 필요
- 와이어프레임 상 로그인 페이지에 Header가 보이지 않아 페이지 별로 Header 컴포넌트를 적용시키기 위해 main에서 제외시킴